### PR TITLE
Support for dynamic components

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Rules
 
-- [component-not-registered](src/component-not-registered.js) - Warn if a component is used in a [SFC file](https://vuejs.org/v2/guide/single-file-components.html) without being registered (a.k.a. a globally registered component). **Does not support dynamically assigned components.**
+- [component-not-registered](src/component-not-registered.js) - Warn if a component is used in a [SFC file](https://vuejs.org/v2/guide/single-file-components.html) without being registered (a.k.a. a globally registered component). **Supports simple dynamically assigned components (only literal values).**
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-plugin-vue": "^5.2.3"
   },
   "devDependencies": {
+    "dedent": "^0.7.0",
     "eslint": "^6.0.1",
     "eslint-config-xo-space": "^0.21.0",
     "eslint-plugin-vue": "^5.2.3",

--- a/src/component-not-registered.js
+++ b/src/component-not-registered.js
@@ -113,22 +113,6 @@ module.exports = {
             report(open, name);
           }
         },
-        "VAttribute[directive=true][key.name.name='bind'][key.argument.name='is']"(node) {
-          if (
-            !node.value || // `<component :is>`
-            node.value.type !== 'VExpressionContainer' ||
-            !node.value.expression // `<component :is="">`
-          ) {
-            return;
-          }
-
-          if (node.value.expression.type === 'Literal') {
-            const name = node.value.expression.value;
-            if (!isComponentRegistered(name)) {
-              report(node.value.expression, name);
-            }
-          }
-        },
         "VAttribute[directive=false][key.name='is']"(node) {
           const name = node.value.value;
           if (!isComponentRegistered(name)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,6 +197,11 @@ decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
+dedent@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+  integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
+
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"


### PR DESCRIPTION
Fixes #1 
Only literal values are supported (no `<component :is="computedProp" />`).
Maybe add a note about this rule's false positives, because that's the reason it's on a separate plugin.
In this case - need to use a disable comment on the reported line, e.g.
`<!-- eslint-disable-next-line @sharkykh/vue-extra/component-not-registered -->`
```vue
<template>
  <!-- ✗ Component "debug" is used but not registered -->
  <debug />
</template>
<script>
const debugComponent = process.env.NODE_ENV === 'production' ? undefined : () => import('./Debug.vue');

export default {
  components: {
    ...debugComponent
  }
};
</script>